### PR TITLE
Optimization.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,8 @@
             :url "http://opensource.org/licenses/MIT"
             :distribution :repo}
   :dependencies [[org.clojure/clojure "[1.2.0,1.5.0]"]]
+  :profiles {:dev {:dependencies [[criterium "0.4.1"]
+                                  [net.sf/javaml "0.1.7"]]
+                   :repositories [["javaml" {:url "http://corp.array.ca/nest-web/maven/"
+                                             :checksum :warn}]]}}
   :plugins [[lein-swank "1.4.4"]])

--- a/src/kdtree.clj
+++ b/src/kdtree.clj
@@ -3,173 +3,224 @@
 ;; at the root of this distribution.
 (ns kdtree)
 
-(defrecord Node [left right #^doubles value #^long depth])
-(defrecord Result [point dist-squared])
+(defrecord Node [left right value])
+(defrecord Result [point ^double dist-squared])
 
-(defn- dist-squared [a b]
+
+(defn- dist-squared [^doubles a ^doubles b]
   "Compute the K-dimensional distance between two points"
-  (reduce + (for [i (range (count a))]
-              (let [v (- (nth a i) (nth b i))]
-                (* v v)))))
+  (loop [res (double 0.0)
+         ind (long 0)]
+    (if (== ind (alength a))
+      res
+      (let [v (- (aget a ind) (aget b ind))]
+        (recur (+ res (* v v)) (inc ind))))))
+
+
+(defn- build-tree-internal [points depth]
+  (if (empty? points) nil
+      (let [point-count (count points)
+            k (count (nth points 0))
+            dimension (mod depth k)
+            points (vec (sort-by #(nth % dimension) points))
+            median (quot point-count 2)
+            split-point (loop [n median]
+                          (cond
+                           (= 0 n) n
+                           (= (nth (points n) dimension)
+                              (nth (points (dec n)) dimension))
+                           (recur (dec n))
+                           :else n))
+            left-tree (build-tree-internal
+                       (subvec points 0 split-point)
+                       (inc depth))
+            right-tree (build-tree-internal
+                        (subvec points (inc split-point))
+                        (inc depth))]
+        (Node. left-tree
+               right-tree
+               (double-array (nth points split-point))
+               (meta (nth points split-point))
+               nil))))
 
 (defn build-tree
   "Construct a Kd-tree from points. Assumes all
 points are of the same dimension."
-  ([points]
-     (build-tree points 0))
-  ([points depth]
-     (let [point-count (count points)]
-       (if (= 0 point-count) nil
-           (let [k (count (nth points 0))
-                 dimension (mod depth k)
-                 points (vec (sort-by #(nth % dimension) points))
-                 median (quot point-count 2)
-                 split-point (loop [n median]
-                               (cond
-                                 (= 0 n) n
-                                 (= (nth (points n) dimension)
-                                    (nth (points (dec n)) dimension))
-                                      (recur (dec n))
-                                 :else n))
-                 left-tree (build-tree
-                            (subvec points 0 split-point)
-                            (inc depth))
-                 right-tree (build-tree
-                             (subvec points (inc split-point))
-                             (inc depth))]
-             (Node. left-tree
-                    right-tree
-                    (into-array Double/TYPE (nth points split-point))
-                    depth
-                    (meta (nth points split-point))
-                    nil))))))
+  [points]
+  (build-tree-internal points 0))
+
+
+
+(defn- insert-internal [tree ^doubles point depth point-meta]
+  (let [k (alength point)
+        dimension (mod depth k)]
+    (if (nil? tree)
+      (Node. nil nil point point-meta nil)
+      (let [^doubles value (:value tree)
+            go-to-left? (< (aget point dimension)
+                           (aget value dimension))
+            left (if go-to-left?
+                   (insert-internal (:left tree) point (inc depth) point-meta)
+                   (:left tree))
+            right (if-not go-to-left?
+                    (insert-internal (:right tree) point (inc depth) point-meta)
+                    (:right tree))]
+        (Node. left right value (meta tree) nil)))))
 
 (defn insert
   "Adds a point to an existing tree."
-  ([tree point] (insert tree point 0))
-  ([tree point depth]
-     (let [k (count point)
-           dimension (mod depth k)]
-      (if (nil? tree)
-        (Node. nil nil (into-array Double/TYPE point) depth (meta point) nil)
-        (let [subtree (if (< (nth point dimension) (nth (:value tree) dimension))
-                        :left :right)
-              updated-subtree (insert (subtree tree) point (inc depth))]
-          (assoc-in tree [subtree] updated-subtree)
-          ;;; I don't understand why, but update-in doesn't work well here
-          ;;; It throws StackoverflowException in test Insert-4d-Example
-          )))))
+  [tree point]
+  (insert-internal tree (double-array point) 0 (meta point)))
+
+
+
+(defn- find-min-internal [tree dimension depth]
+  (when tree
+    (let [k (count (:value tree))
+          min-node (fn [node1 node2]
+                     (let [^doubles value1 (:value node1)
+                           ^doubles value2 (:value node2)]
+                       (if (or (nil? value2)
+                               (< (aget value1 dimension)
+                                  (aget value2 dimension)))
+                         node1 node2)))]
+      (if (= dimension (mod depth k))
+        ;; if we're at the dimension of interest, follow the left branch or
+        ;; take the value - left is always smaller in the current dimension
+        (if (:left tree)
+          (recur (:left tree) dimension (inc depth))
+          tree)
+        ;; otherwise, compare min of self & children
+        (-> tree
+            (min-node (find-min-internal (:left tree) dimension (inc depth)))
+            (min-node (find-min-internal (:right tree) dimension (inc depth))))))))
 
 (defn find-min
   "Locate the point with the smallest value in a given dimension.
 Used internally by the delete function. Runs in O(√n) time for a
 balanced tree."
-  ([tree dimension] (find-min tree dimension 0))
-  ([tree dimension depth]
-     (if (identity tree)
-       (let [k (count (:value tree))]
-         (if (= dimension (mod depth k))
-           ;; if we're at the dimension of interest, follow the left branch or
-           ;; take the value - left is always smaller in the currend dimension
-           (if (nil? (:left tree))
-             (with-meta (vec (:value tree)) (meta tree))
-             (find-min (:left tree) dimension (inc depth)))
-           ;; otherwise, compare min of self & children
-           (first
-            (sort-by #(nth % dimension)
-             (filter identity
-              (list (with-meta (vec (:value tree)) (meta tree))
-                    (find-min (:left tree) dimension (inc depth))
-                    (find-min (:right tree) dimension (inc depth)))))))))))
+  [tree dimension]
+  (let [res (find-min-internal tree dimension 0)]
+      (with-meta (vec (:value res))
+                 (meta res))))
+
+
+
+(defn- points=
+  "Compares 2 points represented by arrays of doubles and return true if they are equal"
+  [^doubles a ^doubles b]
+  (loop [i 0]
+    (cond (== i (alength a)) true
+          (== (aget a i) (aget b i)) (recur (inc i))
+          :else false)))
+
+(defn- delete-internal
+  [tree ^doubles point depth]
+  (when tree
+    (let [^doubles value (:value tree)
+          k (alength value)
+          dimension (mod depth k)]
+      (cond
+
+       ;; point is not here
+       (not (points= point value))
+       (let [go-to-left? (< (aget point dimension) (aget value dimension))
+             left (if go-to-left?
+                    (delete-internal (:left tree) point (inc depth))
+                    (:left tree))
+             right (if-not go-to-left?
+                     (delete-internal (:right tree) point (inc depth))
+                     (:right tree))]
+         (Node. left right (:value tree) (meta tree) nil))
+
+       ;; point is here... three cases:
+
+       ;; right is not null.
+       (:right tree)
+       (let [min (find-min-internal (:right tree) dimension (inc depth))]
+         (Node.
+          (:left tree)
+          (delete-internal (:right tree) (:value min) (inc depth))
+          (:value min)
+          (meta min)
+          nil))
+
+       ;; left if not null
+       (:left tree)
+       (let [min (find-min-internal (:left tree) dimension (inc depth))]
+         (Node.
+          nil
+          (delete-internal (:left tree) (:value min) (inc depth))
+          (:value min)
+          (meta min)
+          nil))
+
+       ;; both left and right are null
+       :default nil))))
 
 (defn delete
   "Delete value at the given point. Runs in O(log n) time for a balanced tree."
-  ([tree point] (delete tree point 0))
-  ([tree point depth]
-     (if (identity tree)
-       (let [k (count (:value tree))
-             dimension (mod depth k)]
-         (cond
-          ;; point is to the left
-          (< (nth point dimension)
-             (nth (:value tree) dimension))
-          (update-in tree [:left] delete point (inc depth))
+  [tree point]
+  (delete-internal tree (double-array point) 0))
 
-          ;; point is to the right
-          (and
-            (>= (nth point dimension)
-                (nth (:value tree) dimension))
-            (not= (map double point) (seq (:value tree))))
-          (update-in tree [:right] delete point (inc depth))
 
-          ;; point is here... three cases:
 
-          ;; leaf node - delete case, so return nil
-          (= nil (:left tree) (:right tree))
-          nil
+(defn- insert-sorted!
+  "Inserts value to sorted transient vector. Vector will not grow
+bigger than n elements."
+  [vec value ^long n]
+  (if (and (== (count vec) n)
+           (> (:dist-squared value) (:dist-squared (nth vec (dec n)))))
+    vec
+    (loop [ind (long 0)
+           value value
+           vec vec]
+     (cond (= ind n) vec
+           (= ind (count vec)) (conj! vec value)
+           :default (let [existing (nth vec ind)]
+                      (if (< (:dist-squared value)
+                             (:dist-squared existing))
+                        (recur (inc ind) existing (assoc! vec ind value))
+                        (recur (inc ind) value vec)))))))
 
-          ;; right is not null.
-          (not (nil? (:right tree)))
-          (let [value (find-min (:right tree) dimension (inc depth))]
-            (Node.
-             (:left tree)
-             (delete (:right tree) value (inc depth))
-             (double-array value)
-             (:depth tree)
-             (meta value)
-             nil))
+(defn- nearest-neighbor-internal [tree ^doubles point n dimension best]
+  (if ;; Empty tree? The best list is unchanged.
+         (nil? tree) best
 
-          ;; right is null, left must not be.
-          true
-          (let [value (find-min (:left tree) dimension (inc depth))]
-            (Node.
-             nil
-             (delete (:left tree) value (inc depth))
-             (double-array value)
-             (:depth tree)
-             (meta value)
-             nil)))))))
+         ;; Otherwise, recurse!
+         (let [dimension (long dimension)
+               next-dimension (unchecked-remainder-int (unchecked-inc dimension) (alength point))
+               ^doubles v (:value tree)
+               dim-dist (double (- (aget point dimension)
+                                   (aget v dimension)))
+               closest-semiplane ((if (> dim-dist 0.0) :right :left) tree)
+               farthest-semiplane ((if (> dim-dist 0.0) :left :right) tree)
+               ;; Compute best list for the near-side of the search order
+               best-with-cur (insert-sorted! best (Result. v
+                                                           (dist-squared v point)
+                                                           (meta tree)
+                                                           nil)
+                                             n)
+               best-near (nearest-neighbor-internal closest-semiplane point n next-dimension best-with-cur)
+               worst-nearest (->> (dec (count best-near))
+                                  (nth best-near)
+                                  :dist-squared)]
 
+           ;; If the square distance of our search node to point in the
+           ;; current dimension is still better than the *worst* of the near-
+           ;; side best list, there may be a better solution on the far
+           ;; side. Compute & combine with near-side solutions.
+           (if (< (* dim-dist dim-dist) worst-nearest)
+             (recur farthest-semiplane point n next-dimension best-near)
+             best-near))))
 
 (defn nearest-neighbor
   "Compute n nearest neighbors for a point. If n is
 omitted, the result is the nearest neighbor;
 otherwise, the result is a list of length n."
-  ([tree point] (first (nearest-neighbor tree point 1 0 nil)))
-  ([tree point n] (nearest-neighbor tree point n 0 nil))
-  ([tree point n depth best]
-     (if ;; Empty tree? The best list is unchanged.
-         (nil? tree) best
-
-         ;; Otherwise, recurse!
-         (take n
-          (sort-by :dist-squared
-           (let [dimension (mod depth (count point))
-                 dim-dist (- (nth point dimension)
-                             (nth (:value tree) dimension))
-                 search-order (if (> dim-dist 0)
-                                (list :right :left)
-                                (list :left :right))
-
-                 ;; Compute best list for the near-side of the search order
-                 best-near (nearest-neighbor
-                            ((first search-order) tree)
-                            point
-                            n
-                            (inc depth)
-                            (cons
-                             (Result. (vec (:value tree))
-                                      (dist-squared (:value tree) point)
-                                      (meta tree)
-                                      nil)
-                             best))]
-             
-             ;; If the square distance of our search node to point in the
-             ;; current dimension is still better than the *worst* of the near-
-             ;; side best list, there may be a better solution on the far
-             ;; side. Compute & combine with near-side solutions.
-             (if (< (* dim-dist dim-dist) (:dist-squared (last best-near)))
-               (concat best-near
-                       (nearest-neighbor
-                        ((last search-order) tree) point n (inc depth) nil))
-               best-near)))))))
+  ([tree point] (first (nearest-neighbor tree point 1)))
+  ([tree point n]
+     (->> (transient [])
+          (nearest-neighbor-internal tree (double-array point) n 0)
+          (persistent!)
+          (map #(update-in % [:point] vec)))))

--- a/test/kdtree/bench.clj
+++ b/test/kdtree/bench.clj
@@ -1,0 +1,116 @@
+(ns kdtree.bench
+  (:require [kdtree :as kd]
+            [criterium.core :as cr])
+  (:import [net.sf.javaml.core.kdtree KDTree]))
+
+(defprotocol GenericKDTree
+  (delete [this point])
+  (nearest-neighbor [this point n])
+  (insert [this point])
+  (delete [this point])
+  (find-min [this dimension]))
+
+(defn build-tree [points type]
+  (case type
+    :clojure (kd/build-tree points)
+    :java (let [tree (KDTree. 2)]
+            (doseq [point points]
+              (.insert tree (double-array point) point))
+            tree)
+    (throw (IllegalArgumentException. (str "Not supported tree type: " type)))))
+
+(extend-protocol GenericKDTree
+  kdtree.Node
+  (delete [this point] (kd/delete this point))
+  (nearest-neighbor [this point n] (kd/nearest-neighbor this point n))
+  (insert [this point] (kd/insert this point))
+  (delete [this point] (kd/delete this point))
+  (find-min [this dimension] (kd/find-min this dimension))
+  KDTree
+  (delete [this point]
+    (->> (into-array Double/TYPE point)
+         (.delete this))
+    this)
+  (nearest-neighbor [this point n]
+    (let [key (into-array Double/TYPE point)
+          neibs (seq (.nearest this key n))
+          dst-sqrd (fn [p2]
+                     (apply + (map (fn [v1 v2]
+                                     (* (- v1 v2)
+                                        (- v1 v2)))
+                                   point p2)))]
+      (map (fn [p] {:point p :dist-squared (dst-sqrd p)}) neibs))))
+
+
+(defn rand-point []
+  [(rand-int 1000000) (rand-int 1000000)])
+
+(def points (doall (repeatedly 5000 rand-point)))
+
+(defn report [name [mean]]
+  (let [[scale unit] (cr/scale-time mean)]
+   (printf "%10s: %s\n" name (str (cr/format-value mean scale unit)))))
+
+(def ^:dynamic *bench-opts* cr/*default-quick-bench-opts*)
+
+(defmacro bench-with-tree [name type expr]
+  `(let [~'tree (build-tree points ~type)]
+     (->> (cr/benchmark ~expr *bench-opts*)
+          :sample-mean
+          (report ~name))))
+
+(defn bench-build [type]
+  (->> (cr/benchmark (build-tree points type) *bench-opts*)
+       :sample-mean
+       (report "build")))
+
+(defn bench-nearest-neighbor [type]
+  (bench-with-tree "near neigh" type
+                   (nearest-neighbor tree (rand-point) 10)))
+
+(defn bench-find-min [type]
+  (when-not (= :java type)
+   (bench-with-tree "find min" type
+                    (find-min tree (rand-int (count (first points)))))))
+
+(defn bench-insert [type]
+  (when-not (= :java type)
+   (bench-with-tree "insert" type
+                    (insert tree (rand-point)))))
+
+(defn bench-delete [type]
+  (when-not (= :java type)
+   (bench-with-tree "delete" type
+                    (delete tree (rand-nth points)))))
+
+(defn bench-all [type & options]
+  (let [bench-opts (if (= (first options) :full) {} *bench-opts*)]
+    (binding [*bench-opts* bench-opts
+              ;;; Probably it bad thing to raise gc threshold
+              ;;; but I want to avoid annoying WARN messages.
+              cr/*final-gc-problem-threshold* 0.5]
+      (println \newline "Benchmarking" (name type) "implementation")
+      (doto type
+        bench-build
+        bench-nearest-neighbor
+        bench-find-min
+        bench-insert
+        bench-delete))))
+
+
+
+#_(
+
+   (bench-build :clojure)
+
+   (bench-nearest-neighbor :clojure)
+
+   (bench-find-min :clojure)
+
+   (bench-insert :clojure)
+
+   (bench-delete :clojure)
+
+   (bench-all :clojure)
+
+   )


### PR DESCRIPTION
I've optimized kd-tree implementation. I compared some functions (especially `nearest-neighbor`) with [Java ML's](http://java-ml.sourceforge.net/) implementation. 
### Benchmark

I benchmarked implementations on tree of 5000 random points using 
For benchmarking I created a tree with 5000 random points and tested all functions using [Criterium](https://github.com/hugoduncan/criterium). Check `test/kdtree/bench.clj` file. It contains all code I used for benchmarking. From java ml's kdtree I used only `nearest neighbor` function because.
- Java ML implementation doesn't have methods to create tree from collection of points
- Java ML implementation is mutable. Comparison of `insert` and `delete` methods on mutable data structure is unfair. 
### Results

| Impl | Nearest neighbor | Build | Find min | Insert | Delete |
| --- | --: | --: | --: | --: | --: |
| Clojure new | 51.92 µs | 67.66 ms | 79.39 µs | 3.01 µs | 324.74 µs |
| Clojure old | 898.00 µs | 77.18 ms | 351.06 µs | 10.55 µs | 357.78 µs |
| Java ML | 12.85 µs | - | - | - | - |
### What changed
- All points converted to double arrays and arrays methods (`aget`, `alength`) are used to work with them.
- `dist-squared` works only with double arrays now.
- `assoc-in` and `update-in` are slower than creating new Node via constructor `(Node. bla bla bla)` though it much more concise. I switched back to constructor.
- Removed `depth` field from `Node`. I didn't found any usage of it in code.
- Extracted all functions that takes additional `depth` argument to *-internal functions. Internal functions are private. I think API is cleaner this way because user should not used functions with `depth` argument because he doesn't not what is it anyway.
- In `nearest-neighbor` function I used transient vector to collect `n` closest points. it's faster than sorting points and taking n first on each recursive call. It may be improved further: Java ML uses binary heap to collect `n` points. It allows adding new point in `O(log n)` where transient vector uses linear search and complexitiy is `O(n)`. The problem is that I don't know how to implement efficient binary heap in clojure. I think it must be mutable to achieve good performance. Nevertheless transient vector are pretty good too compared to sorting on each recursive call.
- In `project.clj` I've added depedenency to criterium and java ml lib in `:dev` profile so it can be easily benchmarked by anyone.
- `test/kdtree/bench.clj` contains becnharmk code. 
