### PR TITLE
Update README.md (missing quote in dependency string)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more detail, refer to [Wikipedia on Kd-trees](http://en.wikipedia.org/wiki/K
 
 Add this to your project.clj `:dependencies` list:
 
-    [clj-kdtree "1.2.0]
+    [clj-kdtree "1.2.0"]
 
 #### Build
 ```clojure


### PR DESCRIPTION
Trivial README tweak to fix missing quote.